### PR TITLE
Fix missing form ID validation in public form submission

### DIFF
--- a/src/components/PublicForm.tsx
+++ b/src/components/PublicForm.tsx
@@ -71,6 +71,10 @@ export const PublicForm: React.FC = () => {
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        if (!formId) {
+            setError("Form non trovato.");
+            return;
+        }
         setIsSubmitting(true);
         setError(null);
         


### PR DESCRIPTION
## Summary
- ensure `PublicForm` validates presence of form ID before submitting data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1c63d59148329ba5ce06eeea0f948